### PR TITLE
Very experimental support for protobuf protocol using

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Contents
 * [Reflection](#pointers-as-optionals)
 * [Additional Archive Controls](#additional-archive-controls)
 * [Variable Length Integers](#variable-length-integers)
+* [Protobuf (Experimental)](#protobuf-experimental)
 * [Benchmark](#benchmark)
 
 Motivation
@@ -483,6 +484,9 @@ zpp::bits::out out(data, zpp::bits::size8b{}); // Use 8 bytes for size.
 
 zpp::bits::in in(data, zpp::bits::size_native{}); // Use std::size_t for size.
 zpp::bits::out out(data, zpp::bits::size_native{}); // Use std::size_t for size.
+
+zpp::bits::in in(data, zpp::bits::no_size{}); // Don't use size, for very special cases, since it is very limiting.
+zpp::bits::out out(data, zpp::bits::no_size{}); // Don't use size, for very special cases, since it is very limiting.
 
 // Can also do it together, for example for 2 bytes size:
 auto [data, in, out] = data_in_out(zpp::bits::size2b{});
@@ -1005,6 +1009,99 @@ auto [data, in, out] = data_in_out(zpp::bits::size_varint{});
 zpp::bits::in in(data, zpp::bits::size_varint{}); // Uses varint to encode size.
 zpp::bits::out out(data, zpp::bits::size_varint{}); // Uses varint to encode size.
 ```
+
+Protobuf (Experimental)
+-----------------------
+The serialization format of this library is not based on any known or accepted format.
+Naturally, other languages do not support this format, which makes it near impossible to use
+the library for cross programming language communication. For this reason the library provides
+support for **protobuf** which is commonly used for binary serialization and cross language
+communication. Please note that protobuf support is highly experimental and may not include
+all of the features, and it is generally slower (around 2-5 times slower) than the stock
+format which aims to be zero overhead.
+
+Starting with the basic message:
+```cpp
+struct example
+{
+    zpp::bits::vint32_t i; // field number is implicitly set to 1,
+    // next field is implicitly 2, and so on
+};
+
+// Serialize as protobuf protocol (as usual, can also define this inside the class
+// with `using serialize = zpp::bits::protocol<zpp::bits::pb{}>;`)
+auto serialize(const example &) -> zpp::bits::protocol<zpp::bits::pb{}>;
+
+// Use archives as usual, specify what kind of size to prefix the message with.
+// We chose no size to demonstrate the actual encoding of the message, but in general
+// it is recommended to size prefix protobuf messages since they are not self terminating.
+auto [data, in, out] = data_in_out(zpp::bits::no_size{});
+
+out(example{.i = 150}).or_throw();
+
+example e;
+in(e).or_throw();
+
+// e.i == 150
+
+// Serialize the message without any size prefix, and check the encoding at compile time:
+static_assert(
+    zpp::bits::to_bytes<zpp::bits::unsized_t<example>{{.i = 150}}>() ==
+    "089601"_decode_hex);
+```
+
+To reserve fields:
+```cpp
+struct example
+{
+    [[no_unique_address]] zpp::bits::pb::reserved _1; // field number 1 is reserved.
+    zpp::bits::vint32_t i; // field number == 2
+    zpp::bits::vsint32_t j; // field number == 3
+    std::uint32_t k; // fixed integer 32, field_number == 4
+};
+```
+
+Like with `zpp::bits::members`, for when it is required, you may specify the number of members
+in the protocol field:
+```cpp
+struct example
+{
+    using serialize = zpp::bits::protocol<zpp::bits::pb{}, 1>; // 1 member.
+
+    zpp::bits::vint32_t i; // field number == 1
+};
+```
+
+Embedded messages are simply nested within the class as data members:
+```cpp
+struct nested_example
+{
+    example nested; // field number == 1
+};
+
+auto serialize(const nested_example &)
+    -> zpp::bits::protocol<zpp::bits::pb{}>;
+
+static_assert(zpp::bits::to_bytes<zpp::bits::unsized_t<nested_example>{
+                  {.nested = example{150}}}>() == "0a03089601"_decode_hex);
+```
+
+Repeated fields are of the form of owning containers:
+```cpp
+struct repeating
+{
+    using serialize = zpp::bits::protocol<zpp::bits::pb{}>;
+
+    std::vector<zpp::bits::vint32_t> integers; // field number == 1
+    std::string characters; // field number == 2
+    std::vector<example> examples; // repeating examples, field number == 3
+};
+```
+
+Currently all missing fields are dropped and not concatenated to the message, for efficiency.
+Any value that is not set in a message leaves the target data member intact, which allows
+to implement defaults for data members by using non-static data member initializer or to initialize
+the data member before deserializing the message.
 
 Benchmark
 ---------

--- a/test/src/test_pb_protocol.cpp
+++ b/test/src/test_pb_protocol.cpp
@@ -1,0 +1,217 @@
+#include "test.h"
+
+namespace test_pb_protocol
+{
+
+using namespace zpp::bits::literals;
+
+struct example
+{
+    zpp::bits::vint32_t i; // field number == 1
+
+    constexpr auto operator<=>(const example &) const = default;
+};
+
+auto serialize(const example &) -> zpp::bits::protocol<zpp::bits::pb{}>;
+
+static_assert(
+    zpp::bits::to_bytes<zpp::bits::unsized_t<example>{{150}}>() ==
+    "089601"_decode_hex);
+
+static_assert(zpp::bits::from_bytes<"089601"_decode_hex,
+                                    zpp::bits::unsized_t<example>>()
+                  .i == 150);
+
+struct nested_example
+{
+    example nested; // field number == 1
+};
+
+auto serialize(const nested_example &)
+    -> zpp::bits::protocol<zpp::bits::pb{}>;
+
+static_assert(zpp::bits::to_bytes<zpp::bits::unsized_t<nested_example>{
+                  {.nested = example{150}}}>() == "0a03089601"_decode_hex);
+
+static_assert(zpp::bits::from_bytes<"0a03089601"_decode_hex,
+                                    zpp::bits::unsized_t<nested_example>>()
+                  .nested.i == 150);
+
+struct nested_reserved_example
+{
+    [[no_unique_address]] zpp::bits::pb::reserved _1{}; // field number == 1
+    [[no_unique_address]] zpp::bits::pb::reserved _2{}; // field number == 2
+    example nested{};                                   // field number == 3
+};
+
+auto serialize(const nested_reserved_example &)
+    -> zpp::bits::protocol<zpp::bits::pb{}>;
+
+static_assert(sizeof(nested_reserved_example) == sizeof(example));
+
+static_assert(
+    zpp::bits::to_bytes<zpp::bits::unsized_t<nested_reserved_example>{
+        {.nested = example{150}}}>() == "1a03089601"_decode_hex);
+
+static_assert(
+    zpp::bits::from_bytes<"1a03089601"_decode_hex,
+                          zpp::bits::unsized_t<nested_reserved_example>>()
+        .nested.i == 150);
+
+struct repeated_integers
+{
+    using serialize = zpp::bits::protocol<zpp::bits::pb{}>;
+    std::vector<zpp::bits::vsint32_t> integers;
+};
+
+TEST(test_pb_protocol, test_repeated_integers)
+{
+    auto [data, in, out] = zpp::bits::data_in_out(zpp::bits::no_size{});
+    out(repeated_integers{.integers = {1, 2, 3, 4, -1, -2, -3, -4}})
+        .or_throw();
+
+    repeated_integers r;
+    in(r).or_throw();
+
+    EXPECT_EQ(
+        r.integers,
+        (std::vector<zpp::bits::vsint32_t>{1, 2, 3, 4, -1, -2, -3, -4}));
+}
+
+struct repeated_examples
+{
+    using serialize = zpp::bits::protocol<zpp::bits::pb{}>;
+    std::vector<example> examples;
+};
+
+TEST(test_pb_protocol, test_repeated_example)
+{
+    auto [data, in, out] = zpp::bits::data_in_out(zpp::bits::no_size{});
+    out(repeated_examples{.examples = {{1}, {2}, {3}, {4}, {-1}, {-2}, {-3}, {-4}}})
+        .or_throw();
+
+    repeated_examples r;
+    in(r).or_throw();
+
+    EXPECT_EQ(r.examples,
+              (std::vector<example>{
+                  {1}, {2}, {3}, {4}, {-1}, {-2}, {-3}, {-4}}));
+}
+
+struct monster {
+    enum color
+    {
+        red,
+        blue,
+        green
+    };
+
+    struct vec3
+    {
+        using serialize = zpp::bits::protocol<zpp::bits::pb{}>;
+        float x;
+        float y;
+        float z;
+
+        bool operator==(const vec3 &) const = default;
+    };
+
+    struct weapon
+    {
+        using serialize = zpp::bits::protocol<zpp::bits::pb{}>;
+        std::string name;
+        int damage;
+
+        bool operator==(const weapon &) const = default;
+    };
+
+    using serialize = zpp::bits::protocol<zpp::bits::pb{}>;
+
+    vec3 pos;
+    zpp::bits::vint32_t mana;
+    int hp;
+    std::string name;
+    std::vector<std::uint8_t> inventory;
+    color color;
+    std::vector<weapon> weapons;
+    weapon equipped;
+    std::vector<vec3> path;
+
+    bool operator==(const monster &) const = default;
+};
+
+TEST(test_pb_protocol, test_monster)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+    monster m = {.pos = {1.0, 2.0, 3.0},
+                 .mana = 200,
+                 .hp = 1000,
+                 .name = "mushroom",
+                 .inventory = {1, 2, 3},
+                 .color = monster::color::blue,
+                 .weapons =
+                     {
+                         monster::weapon{.name = "sword", .damage = 55},
+                         monster::weapon{.name = "spear", .damage = 150},
+                     },
+                 .equipped =
+                     {
+                         monster::weapon{.name = "none", .damage = 15},
+                     },
+                 .path = {monster::vec3{2.0, 3.0, 4.0},
+                          monster::vec3{5.0, 6.0, 7.0}}};
+    out(m).or_throw();
+
+    monster m2;
+    in(m2).or_throw();
+
+    EXPECT_EQ(m.pos, m2.pos);
+    EXPECT_EQ(m.mana, m2.mana);
+    EXPECT_EQ(m.hp, m2.hp);
+    EXPECT_EQ(m.name, m2.name);
+    EXPECT_EQ(m.inventory, m2.inventory);
+    EXPECT_EQ(m.color, m2.color);
+    EXPECT_EQ(m.weapons, m2.weapons);
+    EXPECT_EQ(m.equipped, m2.equipped);
+    EXPECT_EQ(m.path, m2.path);
+    EXPECT_EQ(m, m2);
+}
+
+TEST(test_pb_protocol, test_monster_unsized)
+{
+    auto [data, in, out] = zpp::bits::data_in_out(zpp::bits::no_size{});
+    monster m = {.pos = {1.0, 2.0, 3.0},
+                 .mana = 200,
+                 .hp = 1000,
+                 .name = "mushroom",
+                 .inventory = {1, 2, 3},
+                 .color = monster::color::blue,
+                 .weapons =
+                     {
+                         monster::weapon{.name = "sword", .damage = 55},
+                         monster::weapon{.name = "spear", .damage = 150},
+                     },
+                 .equipped =
+                     {
+                         monster::weapon{.name = "none", .damage = 15},
+                     },
+                 .path = {monster::vec3{2.0, 3.0, 4.0},
+                          monster::vec3{5.0, 6.0, 7.0}}};
+    out(m).or_throw();
+
+    monster m2;
+    in(m2).or_throw();
+
+    EXPECT_EQ(m.pos, m2.pos);
+    EXPECT_EQ(m.mana, m2.mana);
+    EXPECT_EQ(m.hp, m2.hp);
+    EXPECT_EQ(m.name, m2.name);
+    EXPECT_EQ(m.inventory, m2.inventory);
+    EXPECT_EQ(m.color, m2.color);
+    EXPECT_EQ(m.weapons, m2.weapons);
+    EXPECT_EQ(m.equipped, m2.equipped);
+    EXPECT_EQ(m.path, m2.path);
+    EXPECT_EQ(m, m2);
+}
+
+} // namespace test_pb_protocol


### PR DESCRIPTION
`serialize = zpp::bits::protocol<zpp::bits::pb{}>`