### PR TITLE
Support one byte wide, trivially copyable objects

### DIFF
--- a/test/src/test_bitfield.cpp
+++ b/test/src/test_bitfield.cpp
@@ -1,0 +1,29 @@
+#include "test.h"
+
+namespace test_bitfield
+{
+struct Flags
+{
+    unsigned char a : 3;
+    bool b : 1;
+    unsigned char c : 4;
+
+    bool operator==(const Flags&) const = default;
+};
+static_assert(sizeof(Flags) == 1);
+
+TEST(test_bitfield, test)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+    Flags o{0b111, true, 0b1101};
+    out(o).or_throw();
+    EXPECT_EQ(out.position(), 1u);
+
+    Flags i;
+    in(i).or_throw();
+
+    EXPECT_EQ(in.position(), 1u);
+    EXPECT_EQ(o, i);
+}
+
+} // namespace test_bitfield

--- a/zpp_bits.h
+++ b/zpp_bits.h
@@ -2000,7 +2000,7 @@ protected:
             return type::serialize(*this, item);
         } else if constexpr (requires { serialize(*this, item); }) {
             return serialize(*this, item);
-        } else if constexpr (std::is_fundamental_v<type> || std::is_enum_v<type>) {
+        } else if constexpr (std::is_fundamental_v<type> || std::is_enum_v<type> || (sizeof(type) == 1 && std::is_trivially_copyable_v<type>)){
             if constexpr (resizable) {
                 if (auto result = enlarge_for(sizeof(item));
                     failure(result)) [[unlikely]] {
@@ -2559,7 +2559,7 @@ private:
             return type::serialize(*this, item);
         } else if constexpr (requires { serialize(*this, item); }) {
             return serialize(*this, item);
-        } else if constexpr (std::is_fundamental_v<type> || std::is_enum_v<type>) {
+        } else if constexpr (std::is_fundamental_v<type> || std::is_enum_v<type> || (sizeof(type) == 1 && std::is_trivially_copyable_v<type>)) {
             auto size = m_data.size();
             if (sizeof(item) > size - m_position) [[unlikely]] {
                 return std::errc::result_out_of_range;


### PR DESCRIPTION
Implementation of my proposal to add support for serialization one byte wide structs containing bitfields.
#120 