### PR TITLE
Add support for std::complex

### DIFF
--- a/test/src/test_complex.cpp
+++ b/test/src/test_complex.cpp
@@ -1,0 +1,44 @@
+#include <complex>
+
+#include "test.h"
+
+namespace test_complex
+{
+
+TEST(complex, float)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+    out(std::complex<float>(1.5f, 2.0f)).or_throw();
+    EXPECT_EQ(encode_hex(data),
+              "0000c03f"
+              "00000040");
+    std::complex<float> c;
+    in(c).or_throw();
+    EXPECT_EQ(c, std::complex<float>(1.5f, 2.0f));
+}
+
+TEST(complex, integer)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+    out(std::complex<int>(-40, 100)).or_throw();
+    EXPECT_EQ(encode_hex(data),
+              "d8ffffff"
+              "64000000");
+    std::complex<int> c;
+    in(c).or_throw();
+    EXPECT_EQ(c, std::complex<int>(-40, 100));
+}
+
+TEST(complex, unsigned_integer)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+    out(std::complex<unsigned int>(100, 200)).or_throw();
+    EXPECT_EQ(encode_hex(data),
+              "64000000"
+              "c8000000");
+    std::complex<unsigned int> c;
+    in(c).or_throw();
+    EXPECT_EQ(c, std::complex<unsigned int>(100, 200));
+}
+
+}

--- a/zpp_bits.h
+++ b/zpp_bits.h
@@ -6,6 +6,10 @@
 #include <bit>
 #include <climits>
 #include <compare>
+// Support for std::complex tuple protocol
+#if __cpp_lib_tuple_like < 202311L
+#include <complex>
+#endif
 #include <concepts>
 #include <cstddef>
 #include <cstdint>
@@ -1636,6 +1640,28 @@ concept varint = requires
 };
 
 } // namespace concepts
+
+// Support for std::complex tuple protocol
+#if __cpp_lib_tuple_like < 202311L
+template <typename Archive, typename Type>
+ZPP_BITS_INLINE constexpr auto serialize(Archive& archive, const std::complex<Type>& c) 
+    requires (Archive::kind() == kind::out)
+{
+    return archive(c.real(), c.imag());
+}
+
+template <typename Archive, typename Type>
+ZPP_BITS_INLINE constexpr auto serialize(Archive& archive, std::complex<Type>& c) 
+    requires (Archive::kind() == kind::in)
+{
+    Type real_part, imag_part;
+    if (auto result = archive(real_part, imag_part); failure(result)) {
+        return result;
+    }
+    c = std::complex<Type>(real_part, imag_part);
+    return errc{};
+}
+#endif
 
 template <typename Type>
 constexpr auto varint_max_size = sizeof(Type) * CHAR_BIT / (CHAR_BIT - 1) +


### PR DESCRIPTION
std::complex doesn't support structured binding this PR adds template specialization for the serialize function so that std::complex types can be serialized and deserialized.