### PR TITLE
Fix inspection_guarded to exclude types with explicit serializers

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -35,6 +35,28 @@ jobs:
             test_autodetect_members: 0
             with_zpp_throwing: 0
             cxx_standard: 20
+          - name: GCC 13 Ubuntu
+            compiler: gcc
+            compiler_version: 13
+            make: make
+            mode: release
+            os: ubuntu
+            vm_image: ubuntu-22.04
+            test_autodetect_members: 0
+            with_zpp_throwing: 0
+            cxx_standard: 23
+            extra_flags: -Wno-error=stringop-overflow # GCC issue false positive
+          - name: GCC 14 Ubuntu
+            compiler: gcc
+            compiler_version: 14
+            make: make
+            mode: release
+            os: ubuntu
+            vm_image: ubuntu-24.04
+            test_autodetect_members: 0
+            with_zpp_throwing: 0
+            cxx_standard: 23
+            extra_flags: -Wno-error=array-bounds # GCC issue warning about array bounds
           - name: Clang 13 Ubuntu
             compiler: clang
             compiler_version: 13
@@ -45,6 +67,16 @@ jobs:
             test_autodetect_members: 1
             with_zpp_throwing: 1
             cxx_standard: 20
+          - name: Clang 19 Ubuntu
+            compiler: clang
+            compiler_version: 19
+            make: make
+            mode: release
+            os: ubuntu
+            vm_image: ubuntu-24.04
+            test_autodetect_members: 0
+            with_zpp_throwing: 1
+            cxx_standard: 23
           - name: Clang 20 Ubuntu
             compiler: clang
             compiler_version: 20
@@ -55,6 +87,16 @@ jobs:
             test_autodetect_members: 0
             with_zpp_throwing: 1
             cxx_standard: 23
+          - name: Clang 21 Ubuntu
+            compiler: clang
+            compiler_version: 21
+            make: make
+            mode: release
+            os: ubuntu
+            vm_image: ubuntu-24.04
+            test_autodetect_members: 1
+            with_zpp_throwing: 1
+            cxx_standard: 26
           - name: Clang 17 MacOS
             compiler: clang
             compiler_version: 17
@@ -96,6 +138,17 @@ jobs:
             with_zpp_throwing: 0
             cxx_standard: 26
             extra_flags: -Wno-error=array-bounds # GCC issue warning about array bounds
+          - name: GCC 16 Ubuntu
+            compiler: gcc
+            compiler_version: 16
+            make: make
+            mode: release
+            os: ubuntu
+            vm_image: ubuntu-24.04
+            test_autodetect_members: 0
+            with_zpp_throwing: 0
+            cxx_standard: 26
+            extra_flags: -Wno-error=array-bounds # GCC issue warning about array bounds
     env:
       DEBIAN_FRONTEND: noninteractive
       ASAN_OPTIONS: 'alloc_dealloc_mismatch=0'
@@ -116,7 +169,8 @@ jobs:
         if: matrix.config.os == 'ubuntu' && matrix.config.compiler == 'gcc'
         run: |
           sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
-          sudo apt install gcc-${{ matrix.config.compiler_version }} g++-${{ matrix.config.compiler_version }}
+          sudo apt-get update
+          sudo apt-get install -y gcc-${{ matrix.config.compiler_version }} g++-${{ matrix.config.compiler_version }}
       - name: 'install (macos)'
         if: matrix.config.os == 'macos'
         run: |

--- a/test/src/test_inspection_guarded.cpp
+++ b/test/src/test_inspection_guarded.cpp
@@ -1,0 +1,236 @@
+#include "test.h"
+
+// Tests for the inspection_guarded concept fix (issue #207).
+//
+// GCC 16's stricter C++26 structured binding decomposition would attempt to
+// decompose types with explicit archive-based serializers (like optional_ptr,
+// or types with private fields and custom serialize functions), causing
+// compilation failures. The fix adds has_explicit_serialize<Type> to
+// inspection_guarded so the structured binding path is never taken for such
+// types.
+//
+// The exhaustive round-trip coverage lives in test_optional_ptr.cpp and
+// test_issue_207_repro.cpp; this file focuses on the concept-level guarantees
+// and one representative round-trip per distinct type category.
+
+namespace test_inspection_guarded
+{
+
+// --- Compile-time concept checks ---
+
+// optional_ptr has an archive-based explicit serializer and must be guarded.
+static_assert(zpp::bits::concepts::has_explicit_serialize<zpp::bits::optional_ptr<int>>);
+static_assert(zpp::bits::concepts::inspection_guarded<zpp::bits::optional_ptr<int>>);
+
+// std::unique_ptr remains guarded via owning_pointer (unchanged).
+static_assert(zpp::bits::concepts::owning_pointer<std::unique_ptr<int>>);
+static_assert(zpp::bits::concepts::inspection_guarded<std::unique_ptr<int>>);
+
+// Plain aggregates must NOT be inspection_guarded (structured binding path
+// must still apply to ordinary structs).
+struct plain_point { int x; int y; };
+static_assert(!zpp::bits::concepts::inspection_guarded<plain_point>);
+
+// --- Case 1: optional_ptr as a struct member (the root case from #207) ---
+// Using a non-recursive struct to avoid GCC inlining limits on self-referencing types.
+
+struct box
+{
+    int id{};
+    zpp::bits::optional_ptr<int> value;
+};
+
+auto serialize(const box &) -> zpp::bits::members<2>;
+
+TEST(inspection_guarded, optional_ptr_member_with_value)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+
+    box b{42, zpp::bits::optional_ptr<int>{std::make_unique<int>(1337)}};
+    out(b).or_throw();
+
+    box result;
+    in(result).or_throw();
+
+    EXPECT_EQ(result.id, 42);
+    ASSERT_TRUE(result.value != nullptr);
+    EXPECT_EQ(*result.value, 1337);
+}
+
+TEST(inspection_guarded, optional_ptr_member_null)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+
+    box b{7, nullptr};
+    out(b).or_throw();
+
+    box result{100, std::make_unique<int>(99)};
+    in(result).or_throw();
+
+    EXPECT_EQ(result.id, 7);
+    EXPECT_TRUE(result.value == nullptr);
+}
+
+// --- Case 2: private fields with a friend free-function archive serializer ---
+// (Issue #207 second commenter: these types failed without the fix even when
+//  a custom serializer was provided, because inspection_guarded didn't cover
+//  them and structured binding decomposition of private members was attempted.)
+
+class private_with_free_serializer
+{
+public:
+    private_with_free_serializer() = default;
+    private_with_free_serializer(int x, int y) : x_(x), y_(y) {}
+
+    int x() const { return x_; }
+    int y() const { return y_; }
+
+    template <typename Archive>
+    friend auto serialize(Archive & archive, private_with_free_serializer & self)
+    {
+        return archive(self.x_, self.y_);
+    }
+
+    template <typename Archive>
+    friend auto serialize(Archive & archive,
+                          const private_with_free_serializer & self)
+    {
+        return archive(self.x_, self.y_);
+    }
+
+private:
+    int x_{};
+    int y_{};
+};
+
+static_assert(zpp::bits::concepts::has_explicit_serialize<private_with_free_serializer>);
+static_assert(zpp::bits::concepts::inspection_guarded<private_with_free_serializer>);
+
+TEST(inspection_guarded, private_fields_free_serializer_roundtrip)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+
+    private_with_free_serializer p{1337, 1338};
+    out(p).or_throw();
+
+    private_with_free_serializer result;
+    in(result).or_throw();
+
+    EXPECT_EQ(result.x(), 1337);
+    EXPECT_EQ(result.y(), 1338);
+}
+
+// --- Case 3: private fields with a static member serialize function ---
+
+class private_with_static_serializer
+{
+public:
+    private_with_static_serializer() = default;
+    explicit private_with_static_serializer(std::string s, int n)
+        : data_(std::move(s)), count_(n)
+    {
+    }
+
+    const std::string & data() const { return data_; }
+    int count() const { return count_; }
+
+    template <typename Archive>
+    static auto serialize(Archive & archive, private_with_static_serializer & self)
+    {
+        return archive(self.data_, self.count_);
+    }
+
+    template <typename Archive>
+    static auto serialize(Archive & archive,
+                          const private_with_static_serializer & self)
+    {
+        return archive(self.data_, self.count_);
+    }
+
+private:
+    std::string data_;
+    int count_{};
+};
+
+static_assert(zpp::bits::concepts::has_explicit_serialize<private_with_static_serializer>);
+static_assert(zpp::bits::concepts::inspection_guarded<private_with_static_serializer>);
+
+TEST(inspection_guarded, private_fields_static_serializer_roundtrip)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+
+    private_with_static_serializer s{"hello", 42};
+    out(s).or_throw();
+
+    private_with_static_serializer result;
+    in(result).or_throw();
+
+    EXPECT_EQ(result.data(), "hello");
+    EXPECT_EQ(result.count(), 42);
+}
+
+// --- Case 4: optional_ptr<T> where T itself has an explicit serializer ---
+
+class custom_payload
+{
+public:
+    custom_payload() = default;
+    explicit custom_payload(int v) : value_(v) {}
+    int value() const { return value_; }
+
+    template <typename Archive>
+    friend auto serialize(Archive & archive, custom_payload & self)
+    {
+        return archive(self.value_);
+    }
+
+    template <typename Archive>
+    friend auto serialize(Archive & archive, const custom_payload & self)
+    {
+        return archive(self.value_);
+    }
+
+private:
+    int value_{};
+};
+
+TEST(inspection_guarded, optional_ptr_of_explicit_serializer_type)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+
+    zpp::bits::optional_ptr<custom_payload> ptr{std::make_unique<custom_payload>(42)};
+    out(ptr).or_throw();
+
+    zpp::bits::optional_ptr<custom_payload> result;
+    in(result).or_throw();
+
+    ASSERT_TRUE(result != nullptr);
+    EXPECT_EQ(result->value(), 42);
+}
+
+// --- Case 5: struct containing a type with explicit serializer as a member ---
+
+struct wrapper
+{
+    int id{};
+    private_with_free_serializer inner;
+};
+
+auto serialize(const wrapper &) -> zpp::bits::members<2>;
+
+TEST(inspection_guarded, struct_containing_explicit_serializer_type)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+
+    wrapper w{5, {100, 200}};
+    out(w).or_throw();
+
+    wrapper result;
+    in(result).or_throw();
+
+    EXPECT_EQ(result.id, 5);
+    EXPECT_EQ(result.inner.x(), 100);
+    EXPECT_EQ(result.inner.y(), 200);
+}
+
+} // namespace test_inspection_guarded

--- a/test/src/test_issue_207_repro.cpp
+++ b/test/src/test_issue_207_repro.cpp
@@ -1,0 +1,86 @@
+#include "test.h"
+#include <mutex>
+#include <shared_mutex>
+#include <memory>
+
+// Reproduction of issue #207: "optional_ptr and gcc 16.1.0"
+// Source: https://godbolt.org/z/aG1dahGqE
+//
+// The person struct uses an explicit archive-based serialize to control which
+// fields are serialized (excluding std::mutex, std::shared_mutex, etc.).
+// It also holds zpp::bits::optional_ptr<person> members.
+//
+// On GCC 16.1 with C++26 (__cpp_structured_bindings >= 202411L), the library
+// attempts structured binding decomposition of optional_ptr<person> inside
+// number_of_members<optional_ptr<person>>() because optional_ptr is not
+// covered by inspection_guarded. This fails to compile since optional_ptr
+// (derived from unique_ptr) is neither an aggregate nor tuple-like.
+
+namespace test_issue_207_repro
+{
+
+struct person
+{
+    constexpr static auto serialize(auto & archive, auto & self)
+    {
+        return archive(self.name, self.children, self.grandchildren);
+    }
+
+    std::string                                           name;
+    std::mutex                                            m_name;
+    std::vector<std::optional<std::unique_ptr<person>>>   children;
+    std::vector<zpp::bits::optional_ptr<person>>          grandchildren;
+    std::shared_mutex                                     m_children;
+    std::shared_ptr<std::string>                          dog;
+};
+
+TEST(issue_207_repro, person_roundtrip)
+{
+    person p;
+    p.name = "bill";
+    p.children.push_back(std::make_unique<person>());
+    p.children.back().value()->name = "sam";
+    p.grandchildren.push_back(std::make_unique<person>());
+    p.grandchildren.back()->name = "grace";
+    p.dog = std::make_shared<std::string>("growler");
+
+    std::vector<std::byte> data;
+    zpp::bits::out out{data};
+    out(p).or_throw();
+
+    person p2;
+    zpp::bits::in in{data};
+    in(p2).or_throw();
+
+    EXPECT_EQ(p2.name, "bill");
+    ASSERT_EQ(p2.children.size(), 1u);
+    ASSERT_TRUE(p2.children[0].has_value());
+    EXPECT_EQ((*p2.children[0])->name, "sam");
+    ASSERT_EQ(p2.grandchildren.size(), 1u);
+    EXPECT_EQ(p2.grandchildren[0]->name, "grace");
+}
+
+TEST(issue_207_repro, optional_ptr_member_null_and_nonnull)
+{
+    person p;
+    p.name = "alice";
+    p.grandchildren.push_back(nullptr);
+    p.grandchildren.push_back(std::make_unique<person>());
+    p.grandchildren.back()->name = "bob";
+
+    std::vector<std::byte> data;
+    zpp::bits::out out{data};
+    out(p).or_throw();
+
+    person p2;
+    zpp::bits::in in{data};
+    in(p2).or_throw();
+
+    EXPECT_EQ(p2.name, "alice");
+    ASSERT_EQ(p2.grandchildren.size(), 2u);
+    EXPECT_TRUE(p2.grandchildren[0] == nullptr);
+    ASSERT_TRUE(p2.grandchildren[1] != nullptr);
+    EXPECT_EQ(p2.grandchildren[1]->name, "bob");
+}
+
+} // namespace test_issue_207_repro

--- a/zpp_bits.h
+++ b/zpp_bits.h
@@ -950,7 +950,8 @@ concept array =
 template <typename Type>
 concept inspection_guarded =
     (container<Type> && !array<Type>) || owning_pointer<Type> ||
-    variant<Type> || optional<Type> || bitset<Type>;
+    variant<Type> || optional<Type> || bitset<Type> ||
+    has_explicit_serialize<Type>;
 
 } // namespace concepts
 


### PR DESCRIPTION
## Summary

Fixes #207

- Types with archive-based explicit serializers (like `optional_ptr`, or types with private fields and a custom `serialize` function) were not covered by `inspection_guarded`
- GCC 16's stricter C++26 structured binding decomposition (`__cpp_structured_bindings >= 202411L`) then attempted to decompose these types, causing a compilation failure
- Adding `has_explicit_serialize<Type>` to `inspection_guarded` correctly prevents the structured binding path from being taken for any type that already has an explicit serializer

## Root cause

`optional_ptr<T>` derives from `std::unique_ptr<T>`, but `traits::is_unique_ptr` only matches the exact `std::unique_ptr` type — not derived types. So `optional_ptr` failed the `owning_pointer` concept and therefore `inspection_guarded`. The same root cause affects the second case reported in the issue: types with private fields and custom serializers.

## Test plan
- [x] Existing `test_optional_ptr` test compiles cleanly
- [x] Added `test_inspection_guarded` (concept-level `static_assert`s + representative round-trips per type category) and `test_issue_207_repro` (the exact repro from the issue)
- [x] GCC 16 + C++26 job added to the CI matrix to verify the original repro compiles and passes (also added GCC 13/14, Clang 19/21 coverage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)