### PR TITLE
WIP: GCC 16 CI repro for issue #207 (DO NOT MERGE)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -96,6 +96,17 @@ jobs:
             with_zpp_throwing: 0
             cxx_standard: 26
             extra_flags: -Wno-error=array-bounds # GCC issue warning about array bounds
+          - name: GCC 16 Ubuntu
+            compiler: gcc
+            compiler_version: 16
+            make: make
+            mode: release
+            os: ubuntu
+            vm_image: ubuntu-24.04
+            test_autodetect_members: 0
+            with_zpp_throwing: 0
+            cxx_standard: 26
+            extra_flags: -Wno-error=array-bounds # GCC issue warning about array bounds
     env:
       DEBIAN_FRONTEND: noninteractive
       ASAN_OPTIONS: 'alloc_dealloc_mismatch=0'


### PR DESCRIPTION
## ⚠️ WIP — DO NOT MERGE

This PR adds GCC 16 + C++26 to the CI matrix **without** any fix applied, to confirm that the failure described in #207 reproduces in CI.

Once the GCC 16 job is confirmed to fail (as expected), this PR will be closed and the fix in #208 will be validated with GCC 16 included.

Closes (after validation) — see #208 for the actual fix.