### PR TITLE
REPRO: issue #207 — inspection_guarded misses explicit serializers (DO NOT MERGE)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -96,6 +96,17 @@ jobs:
             with_zpp_throwing: 0
             cxx_standard: 26
             extra_flags: -Wno-error=array-bounds # GCC issue warning about array bounds
+          - name: GCC 16 Ubuntu
+            compiler: gcc
+            compiler_version: 16
+            make: make
+            mode: release
+            os: ubuntu
+            vm_image: ubuntu-24.04
+            test_autodetect_members: 0
+            with_zpp_throwing: 0
+            cxx_standard: 26
+            extra_flags: -Wno-error=array-bounds
     env:
       DEBIAN_FRONTEND: noninteractive
       ASAN_OPTIONS: 'alloc_dealloc_mismatch=0'

--- a/test/src/test_issue_207_repro.cpp
+++ b/test/src/test_issue_207_repro.cpp
@@ -1,0 +1,116 @@
+#include "test.h"
+
+// Reproduction test for issue #207:
+// "optional_ptr and gcc 16.1.0"
+//
+// Root cause: types with explicit archive-based serializers (optional_ptr,
+// types with private fields + custom serialize) are not covered by the
+// inspection_guarded concept. On GCC 16 + C++26, this causes the library to
+// attempt structured binding decomposition of those types, failing to compile.
+//
+// The fix adds has_explicit_serialize<Type> to inspection_guarded.
+// These static_asserts verify that invariant holds — they FAIL on unfixed
+// code and PASS after the fix, across all compilers and C++ standard versions.
+
+namespace test_issue_207_repro
+{
+
+// optional_ptr<T> has a free-function serialize(archive, optional_ptr<T>).
+// It must be inspection_guarded so the structured binding path is never taken.
+static_assert(zpp::bits::concepts::has_explicit_serialize<zpp::bits::optional_ptr<int>>,
+    "optional_ptr must have an explicit serializer detected");
+
+static_assert(zpp::bits::concepts::inspection_guarded<zpp::bits::optional_ptr<int>>,
+    "optional_ptr must be inspection_guarded (issue #207: unfixed code fails this)");
+
+// A type with private fields and a friend archive serializer (second case from #207).
+class private_custom_serialize
+{
+public:
+    private_custom_serialize() = default;
+    private_custom_serialize(int a, int b) : a_(a), b_(b) {}
+
+    template <typename Archive>
+    friend auto serialize(Archive & archive, private_custom_serialize & self)
+    {
+        return archive(self.a_, self.b_);
+    }
+
+    template <typename Archive>
+    friend auto serialize(Archive & archive, const private_custom_serialize & self)
+    {
+        return archive(self.a_, self.b_);
+    }
+
+private:
+    int a_{};
+    int b_{};
+};
+
+static_assert(zpp::bits::concepts::has_explicit_serialize<private_custom_serialize>,
+    "type with friend archive serializer must be detected as has_explicit_serialize");
+
+static_assert(zpp::bits::concepts::inspection_guarded<private_custom_serialize>,
+    "type with private fields + explicit serializer must be inspection_guarded "
+    "(without fix, structured binding decomposition of private members is attempted)");
+
+// A type with a static member archive serializer.
+class static_custom_serialize
+{
+public:
+    static_custom_serialize() = default;
+    explicit static_custom_serialize(int v) : v_(v) {}
+
+    template <typename Archive>
+    static auto serialize(Archive & archive, static_custom_serialize & self)
+    {
+        return archive(self.v_);
+    }
+
+    template <typename Archive>
+    static auto serialize(Archive & archive, const static_custom_serialize & self)
+    {
+        return archive(self.v_);
+    }
+
+private:
+    int v_{};
+};
+
+static_assert(zpp::bits::concepts::has_explicit_serialize<static_custom_serialize>,
+    "type with static member archive serializer must be detected as has_explicit_serialize");
+
+static_assert(zpp::bits::concepts::inspection_guarded<static_custom_serialize>,
+    "type with static member archive serializer must be inspection_guarded");
+
+// Sanity: plain aggregates must NOT be inspection_guarded.
+// If this fires, the fix over-guards and would break member auto-detection.
+struct plain_aggregate { int x; int y; };
+static_assert(!zpp::bits::concepts::inspection_guarded<plain_aggregate>,
+    "plain aggregates must NOT be inspection_guarded (member detection must still work)");
+
+// Runtime test: ensure optional_ptr still serializes correctly after the fix.
+TEST(issue_207_repro, optional_ptr_roundtrip_valid)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+    out(zpp::bits::optional_ptr<int>{std::make_unique<int>(0x1337)}).or_throw();
+
+    zpp::bits::optional_ptr<int> result;
+    in(result).or_throw();
+
+    ASSERT_TRUE(result != nullptr);
+    EXPECT_EQ(*result, 0x1337);
+}
+
+TEST(issue_207_repro, optional_ptr_roundtrip_null)
+{
+    auto [data, in, out] = zpp::bits::data_in_out();
+    out(zpp::bits::optional_ptr<int>{}).or_throw();
+
+    zpp::bits::optional_ptr<int> result{std::make_unique<int>(99)};
+    in(result).or_throw();
+
+    EXPECT_TRUE(result == nullptr);
+}
+
+} // namespace test_issue_207_repro


### PR DESCRIPTION
## ⚠️ Repro branch — DO NOT MERGE

This PR demonstrates the root cause of #207 across **all CI compilers**, without requiring GCC 16.1.0's specific C++26 structured binding support.

## What this shows

The `inspection_guarded` concept on the **unfixed** codebase does not cover:
- `optional_ptr<T>` (derives from `unique_ptr` but `is_unique_ptr` only matches the exact type)
- Types with private fields and explicit archive-based serializers

The test file `test_issue_207_repro.cpp` contains static_asserts that verify these types **must** be `inspection_guarded`. These asserts **fail to compile** on this branch (no fix applied), proving the bug exists at the concept level.

On GCC 16.1.0 with `__cpp_structured_bindings >= 202411L`, this missing guard causes the library to attempt structured binding decomposition of `optional_ptr`, resulting in a hard compilation error.

## Expected CI result

**All builds should FAIL** — the static_asserts trigger a compile error on unfixed code.

Once confirmed, this PR will be closed and #208 (which adds `has_explicit_serialize<Type>` to `inspection_guarded`) will be the fix.