### PR TITLE
REPRO: issue #207 — Godbolt repro on GCC 16 (DO NOT MERGE)

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -96,6 +96,17 @@ jobs:
             with_zpp_throwing: 0
             cxx_standard: 26
             extra_flags: -Wno-error=array-bounds # GCC issue warning about array bounds
+          - name: GCC 16 Ubuntu
+            compiler: gcc
+            compiler_version: 16
+            make: make
+            mode: release
+            os: ubuntu
+            vm_image: ubuntu-24.04
+            test_autodetect_members: 0
+            with_zpp_throwing: 0
+            cxx_standard: 26
+            extra_flags: -Wno-error=array-bounds
     env:
       DEBIAN_FRONTEND: noninteractive
       ASAN_OPTIONS: 'alloc_dealloc_mismatch=0'

--- a/test/src/test_issue_207_repro.cpp
+++ b/test/src/test_issue_207_repro.cpp
@@ -1,0 +1,86 @@
+#include "test.h"
+#include <mutex>
+#include <shared_mutex>
+#include <memory>
+
+// Reproduction of issue #207: "optional_ptr and gcc 16.1.0"
+// Source: https://godbolt.org/z/aG1dahGqE
+//
+// The person struct uses an explicit archive-based serialize to control which
+// fields are serialized (excluding std::mutex, std::shared_mutex, etc.).
+// It also holds zpp::bits::optional_ptr<person> members.
+//
+// On GCC 16.1 with C++26 (__cpp_structured_bindings >= 202411L), the library
+// attempts structured binding decomposition of optional_ptr<person> inside
+// number_of_members<optional_ptr<person>>() because optional_ptr is not
+// covered by inspection_guarded. This fails to compile since optional_ptr
+// (derived from unique_ptr) is neither an aggregate nor tuple-like.
+
+namespace test_issue_207_repro
+{
+
+struct person
+{
+    constexpr static auto serialize(auto & archive, auto & self)
+    {
+        return archive(self.name, self.children, self.grandchildren);
+    }
+
+    std::string                                           name;
+    std::mutex                                            m_name;
+    std::vector<std::optional<std::unique_ptr<person>>>   children;
+    std::vector<zpp::bits::optional_ptr<person>>          grandchildren;
+    std::shared_mutex                                     m_children;
+    std::shared_ptr<std::string>                          dog;
+};
+
+TEST(issue_207_repro, person_roundtrip)
+{
+    person p;
+    p.name = "bill";
+    p.children.push_back(std::make_unique<person>());
+    p.children.back().value()->name = "sam";
+    p.grandchildren.push_back(std::make_unique<person>());
+    p.grandchildren.back()->name = "grace";
+    p.dog = std::make_shared<std::string>("growler");
+
+    std::vector<std::byte> data;
+    zpp::bits::out out{data};
+    out(p).or_throw();
+
+    person p2;
+    zpp::bits::in in{data};
+    in(p2).or_throw();
+
+    EXPECT_EQ(p2.name, "bill");
+    ASSERT_EQ(p2.children.size(), 1u);
+    ASSERT_TRUE(p2.children[0].has_value());
+    EXPECT_EQ((*p2.children[0])->name, "sam");
+    ASSERT_EQ(p2.grandchildren.size(), 1u);
+    EXPECT_EQ(p2.grandchildren[0]->name, "grace");
+}
+
+TEST(issue_207_repro, optional_ptr_member_null_and_nonnull)
+{
+    person p;
+    p.name = "alice";
+    p.grandchildren.push_back(nullptr);
+    p.grandchildren.push_back(std::make_unique<person>());
+    p.grandchildren.back()->name = "bob";
+
+    std::vector<std::byte> data;
+    zpp::bits::out out{data};
+    out(p).or_throw();
+
+    person p2;
+    zpp::bits::in in{data};
+    in(p2).or_throw();
+
+    EXPECT_EQ(p2.name, "alice");
+    ASSERT_EQ(p2.grandchildren.size(), 2u);
+    EXPECT_TRUE(p2.grandchildren[0] == nullptr);
+    ASSERT_TRUE(p2.grandchildren[1] != nullptr);
+    EXPECT_EQ(p2.grandchildren[1]->name, "bob");
+}
+
+} // namespace test_issue_207_repro


### PR DESCRIPTION
## ⚠️ Repro branch — DO NOT MERGE

Mirrors the exact failing code from https://godbolt.org/z/aG1dahGqE.

## The bug

A `person` struct with:
- An archive-based `static constexpr serialize()` to control which fields are serialized
- `std::vector<zpp::bits::optional_ptr<person>>` grandchildren
- Non-serializable members (`std::mutex`, `std::shared_mutex`) excluded by the custom serializer

On **GCC 16.1 with C++26** (`__cpp_structured_bindings >= 202411L`), `number_of_members<optional_ptr<person>>()` takes the structured binding path (because `optional_ptr` is not `inspection_guarded`). Since `optional_ptr` derives from `std::unique_ptr` (not an aggregate, not tuple-like), the structured binding decomposition fails with a hard compile error.

## Expected CI result

**GCC 16 build should FAIL** with a structured binding error. Other compilers may pass if they don't yet define `__cpp_structured_bindings >= 202411L`.

See PR #208 for the fix.