### PR TITLE
Suppress GCC stringop-overflow false positive

### DIFF
--- a/zpp_bits.h
+++ b/zpp_bits.h
@@ -2178,6 +2178,7 @@ protected:
 #if !defined __clang__ && defined __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Warray-bounds"
+#pragma GCC diagnostic ignored "-Wstringop-overflow"
 #endif
                 std::memcpy(m_data.data() + m_position,
                             item.data(),


### PR DESCRIPTION
Suppress GCC’s false-positive -Wstringop-overflow warning when serializing dynamic byte containers.

Fixes eyalz800/zpp_bits#213.