### PR TITLE
zpp::bits::members is not necessary for the version example

### DIFF
--- a/README.md
+++ b/README.md
@@ -590,8 +590,6 @@ namespace v1
 {
 struct person
 {
-    using serialize = zpp::bits::members<2>;
-
     auto get_hobby() const
     {
         return "<none>"sv;
@@ -606,8 +604,6 @@ namespace v2
 {
 struct person
 {
-    using serialize = zpp::bits::members<3>;
-
     auto get_hobby() const
     {
         return std::string_view(hobby);


### PR DESCRIPTION
I suggest removing the zpp::bits::members<*> declaration from the docs about versioning, as it's not needed and it may confuse people.