### PR TITLE
Add an opt-in nesting limit for self referencing types

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ operator from return value based, or by examining the internal error code of `st
 which one you used:
 1. `std::errc::result_out_of_range` - attempting to write or read from a too short buffer.
 2. `std::errc::no_buffer_space` - growing buffer would grow beyond the allocation limits or overflow.
-3. `std::errc::value_too_large` - varint (variable length integer) encoding is beyond the representation limits.
+3. `std::errc::value_too_large` - varint (variable length integer) encoding is beyond the representation limits,
+or nesting is beyond the user defined nesting limit.
 4. `std::errc::message_size` - message size is beyond the user defined allocation limits.
 5. `std::errc::not_supported` - attempt to call an RPC that is not listed as supported.
 6. `std::errc::bad_message` - attempt to read a variant of unrecognized type.
@@ -1028,6 +1029,22 @@ which covers resizable containers such as `std::vector` and `std::string`,
 associative containers such as `std::map` and `std::unordered_set`, and
 length delimited protobuf fields. The limit is evaluated per container
 rather than as a budget for the whole message.
+
+A self referencing type nests as deeply as the message says it does, and each
+level costs a stack frame, so a message can ask for more nesting than the
+stack has room for. How deeply such a type may nest can be limited using
+`zpp::bits::nesting_limit<N>{}`, which fails with
+`std::errc::value_too_large` past `N` levels:
+```cpp
+zpp::bits::in in(data, zpp::bits::nesting_limit<128>{});
+auto [in, out] = in_out(data, zpp::bits::nesting_limit<128>{});
+```
+
+The limit counts self referencing types and nested protobuf messages. Types
+that cannot nest without bound, such as plainly nested containers, are not
+counted and are never rejected by it. Archives that are not given the option
+carry no nesting state and emit no checks, so nesting is unlimited by default
+and there is nothing to pay for not using it.
 
 For best correctness, when using growing buffer for output, if the buffer was grown, the buffer is resized
 in the end for the exact position of the output archive, this incurs an extra resize

--- a/test/src/test_nesting_limit.cpp
+++ b/test/src/test_nesting_limit.cpp
@@ -1,0 +1,234 @@
+#include "test.h"
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <span>
+#include <vector>
+
+namespace test_nesting_limit
+{
+
+// The canonical self referencing shape: a node that holds more of itself.
+// Every level is one more level of nesting in the encoded message, and one
+// more stack frame while deserializing.
+struct tree
+{
+    std::uint8_t value{};
+    std::vector<tree> children;
+};
+
+// A `unique_ptr` member is always present rather than optional, so a chain of
+// these never terminates - deserializing one recurses until the input runs
+// out. Two bytes of input buy one more level of recursion.
+struct chain
+{
+    std::uint8_t value{};
+    std::unique_ptr<chain> next;
+};
+
+// Protobuf messages nest through a fresh archive per level rather than by
+// recursing on one archive, so they exercise a different path.
+//
+// Protobuf itself allows a message to reference itself, but a self
+// referencing message does not currently compile here ("deduced return type
+// cannot be used before it is defined"), so the nesting below is static.
+struct pb_leaf
+{
+    zpp::bits::vint32_t value;
+
+    using serialize = zpp::bits::pb_protocol;
+};
+
+struct pb_middle
+{
+    pb_leaf leaf;
+
+    using serialize = zpp::bits::pb_protocol;
+};
+
+struct pb_root
+{
+    pb_middle middle;
+
+    using serialize = zpp::bits::pb_protocol;
+};
+
+static_assert(zpp::bits::concepts::self_referencing<tree>);
+static_assert(zpp::bits::concepts::self_referencing<chain>);
+
+// Builds a tree that is `depth` levels deep, counting the root as level one.
+template <typename Type>
+static Type nested(std::size_t depth)
+{
+    Type root;
+    auto current = &root;
+    for (std::size_t level = 1; level < depth; ++level) {
+        current->children.resize(1);
+        current = &current->children.front();
+    }
+    return root;
+}
+
+template <typename Type>
+static std::size_t depth_of(const Type & root)
+{
+    std::size_t depth = 1;
+    for (auto current = &root; !current->children.empty();
+         current = &current->children.front()) {
+        ++depth;
+    }
+    return depth;
+}
+
+TEST(test_nesting_limit, costs_nothing_when_not_requested)
+{
+    using archive = zpp::bits::in<std::span<const std::byte>>;
+
+    static_assert(sizeof(archive) ==
+                  sizeof(std::span<const std::byte>) +
+                      sizeof(std::size_t));
+}
+
+TEST(test_nesting_limit, within_limit_is_accepted)
+{
+    constexpr auto limit = 4;
+
+    std::vector<std::byte> data;
+    zpp::bits::out{data}(nested<tree>(limit)).or_throw();
+
+    tree restored;
+    zpp::bits::in in{data, zpp::bits::nesting_limit<limit>()};
+    static_assert(decltype(in)::nesting_depth_limit == limit);
+
+    in(restored).or_throw();
+    EXPECT_EQ(depth_of(restored), std::size_t(limit));
+}
+
+TEST(test_nesting_limit, beyond_limit_is_rejected)
+{
+    constexpr auto limit = 4;
+
+    std::vector<std::byte> data;
+    zpp::bits::out{data}(nested<tree>(limit + 1)).or_throw();
+
+    tree restored;
+    zpp::bits::in in{data, zpp::bits::nesting_limit<limit>()};
+
+    EXPECT_EQ(in(restored), std::errc::value_too_large);
+}
+
+TEST(test_nesting_limit, output_beyond_limit_is_rejected)
+{
+    constexpr auto limit = 3;
+
+    auto deep = nested<tree>(limit + 1);
+
+    std::vector<std::byte> data;
+    zpp::bits::out out{data, zpp::bits::nesting_limit<limit>()};
+    static_assert(decltype(out)::nesting_depth_limit == limit);
+
+    EXPECT_EQ(out(deep), std::errc::value_too_large);
+}
+
+TEST(test_nesting_limit, output_within_limit_is_accepted)
+{
+    constexpr auto limit = 4;
+
+    auto deep = nested<tree>(limit);
+
+    std::vector<std::byte> data;
+    zpp::bits::out{data, zpp::bits::nesting_limit<limit>()}(deep).or_throw();
+    EXPECT_FALSE(data.empty());
+}
+
+// `pb_root` nests three messages deep: root, middle, leaf.
+static auto encoded_pb_root()
+{
+    std::vector<std::byte> data;
+    zpp::bits::out{data, zpp::bits::size_varint{}}(
+        zpp::bits::unsized(pb_root{.middle = {.leaf = {150}}}))
+        .or_throw();
+    return data;
+}
+
+TEST(test_nesting_limit, protobuf_beyond_limit_is_rejected)
+{
+    auto data = encoded_pb_root();
+
+    pb_root restored;
+    zpp::bits::in in{data,
+                     zpp::bits::size_varint{},
+                     zpp::bits::nesting_limit<2>()};
+
+    EXPECT_EQ(in(zpp::bits::unsized(restored)),
+              std::errc::value_too_large);
+}
+
+TEST(test_nesting_limit, protobuf_within_limit_is_accepted)
+{
+    auto data = encoded_pb_root();
+
+    pb_root restored;
+    zpp::bits::in in{data,
+                     zpp::bits::size_varint{},
+                     zpp::bits::nesting_limit<3>()};
+
+    in(zpp::bits::unsized(restored)).or_throw();
+    EXPECT_EQ(restored.middle.leaf.value.value, 150);
+}
+
+TEST(test_nesting_limit, protobuf_output_beyond_limit_is_rejected)
+{
+    std::vector<std::byte> data;
+    zpp::bits::out out{
+        data, zpp::bits::size_varint{}, zpp::bits::nesting_limit<2>()};
+
+    EXPECT_EQ(out(zpp::bits::unsized(pb_root{.middle = {.leaf = {150}}})),
+              std::errc::value_too_large);
+}
+
+TEST(test_nesting_limit, deeply_nested_input_is_rejected_without_recursing)
+{
+    // Without a limit this input recurses roughly 100000 levels deep and
+    // exhausts the stack. Two bytes buy one more level.
+    std::vector<std::byte> data(200000, std::byte{0x01});
+
+    chain head;
+    zpp::bits::in in{data, zpp::bits::nesting_limit<128>()};
+
+    EXPECT_EQ(in(head), std::errc::value_too_large);
+}
+
+TEST(test_nesting_limit, unlimited_by_default)
+{
+    constexpr auto depth = 512;
+
+    std::vector<std::byte> data;
+    zpp::bits::out{data}(nested<tree>(depth)).or_throw();
+
+    tree restored;
+    zpp::bits::in{data}(restored).or_throw();
+
+    EXPECT_EQ(depth_of(restored), std::size_t(depth));
+}
+
+TEST(test_nesting_limit, non_nesting_types_are_unaffected)
+{
+    // Deeply nested containers are not self referencing, so the limit does
+    // not apply to them however deep the type is.
+    constexpr auto limit = 2;
+
+    std::vector<std::vector<std::vector<std::uint32_t>>> deep{
+        {{1, 2}, {3}}, {{4, 5, 6}}};
+
+    std::vector<std::byte> data;
+    zpp::bits::out{data, zpp::bits::nesting_limit<limit>()}(deep).or_throw();
+
+    decltype(deep) restored;
+    zpp::bits::in{data, zpp::bits::nesting_limit<limit>()}(restored)
+        .or_throw();
+
+    EXPECT_EQ(restored, deep);
+}
+
+} // namespace test_nesting_limit

--- a/zpp_bits.h
+++ b/zpp_bits.h
@@ -709,6 +709,41 @@ constexpr auto alloc_limit()
 }
 
 template <typename Option, typename... Options>
+constexpr auto get_nesting_limit()
+{
+    if constexpr (requires {
+                      std::remove_cvref_t<Option>::nesting_limit_value;
+                  }) {
+        return std::remove_cvref_t<Option>::nesting_limit_value;
+    } else if constexpr (sizeof...(Options) != 0) {
+        return get_nesting_limit<Options...>();
+    } else {
+        return std::numeric_limits<std::size_t>::max();
+    }
+}
+
+template <typename... Options>
+constexpr auto nesting_limit()
+{
+    if constexpr (sizeof...(Options) != 0) {
+        return get_nesting_limit<Options...>();
+    } else {
+        return std::numeric_limits<std::size_t>::max();
+    }
+}
+
+// Occupies no space in an archive that was not given a nesting limit.
+struct no_nesting_depth
+{
+};
+
+template <std::size_t Limit>
+using nesting_depth_t =
+    std::conditional_t<Limit != std::numeric_limits<std::size_t>::max(),
+                       std::size_t,
+                       no_nesting_depth>;
+
+template <typename Option, typename... Options>
 constexpr auto get_enlarger()
 {
     if constexpr (requires {
@@ -1113,6 +1148,17 @@ template <std::size_t Size>
 struct alloc_limit : option<alloc_limit<Size>>
 {
     constexpr static auto alloc_limit_value = Size;
+};
+
+// Limits how deeply a self referencing type may nest. Deserializing a self
+// referencing type recurses once per level of nesting, so a message that
+// nests far deeper than the data it describes is worth rejecting before the
+// stack runs out. Opt in only - archives that are not given this option
+// carry no nesting state and emit no checks.
+template <std::size_t Size>
+struct nesting_limit : option<nesting_limit<Size>>
+{
+    constexpr static auto nesting_limit_value = Size;
 };
 
 template <std::size_t Multiplier, std::size_t Divisor = 1>
@@ -1906,6 +1952,47 @@ struct size_varint : option<size_varint>
 };
 } // namespace options
 
+// Counts one level of nesting for the lifetime of the guard. Compiles away
+// entirely for archives that were not given a nesting limit.
+template <typename Archive>
+struct nesting_guard
+{
+    ZPP_BITS_INLINE constexpr explicit nesting_guard(Archive & archive) :
+        m_archive(archive)
+    {
+        if constexpr (Archive::nesting_limited) {
+            if (archive.nesting_depth() >= Archive::nesting_depth_limit)
+                [[unlikely]] {
+                result = errc{std::errc::value_too_large};
+                return;
+            }
+            ++archive.nesting_depth();
+            m_entered = true;
+        }
+    }
+
+    nesting_guard(const nesting_guard &) = delete;
+    nesting_guard & operator=(const nesting_guard &) = delete;
+
+    ZPP_BITS_INLINE constexpr ~nesting_guard()
+    {
+        if constexpr (Archive::nesting_limited) {
+            if (m_entered) {
+                --m_archive.nesting_depth();
+            }
+        }
+    }
+
+    errc result{};
+
+private:
+    Archive & m_archive;
+    bool m_entered{};
+};
+
+template <typename Archive>
+nesting_guard(Archive &) -> nesting_guard<Archive>;
+
 template <concepts::byte_view ByteView, typename... Options>
 class basic_out
 {
@@ -1942,6 +2029,12 @@ public:
     using default_size_type = traits::default_size_type_t<Options...>;
 
     constexpr static auto allocation_limit = traits::alloc_limit<Options...>();
+
+    constexpr static auto nesting_depth_limit =
+        traits::nesting_limit<Options...>();
+
+    constexpr static auto nesting_limited =
+        nesting_depth_limit != std::numeric_limits<std::size_t>::max();
 
     constexpr static auto enlarger = traits::enlarger<Options...>();
 
@@ -2000,6 +2093,11 @@ public:
     constexpr auto processed_data()
     {
         return std::span<byte_type>{m_data.data(), m_position};
+    }
+
+    constexpr auto & nesting_depth()
+    {
+        return m_nesting;
     }
 
     constexpr void reset(std::size_t position = 0)
@@ -2195,11 +2293,21 @@ protected:
                                                           type>) {
             return serialize_one(as_bytes(item));
         } else if constexpr (concepts::self_referencing<type>) {
-            return visit_members(
+            if constexpr (nesting_limited) {
+                if (m_nesting >= nesting_depth_limit) [[unlikely]] {
+                    return errc{std::errc::value_too_large};
+                }
+                ++m_nesting;
+            }
+            auto result = visit_members(
                 item,
                 [&](auto &&... items) constexpr {
                     return serialize_many(items...);
                 });
+            if constexpr (nesting_limited) {
+                --m_nesting;
+            }
+            return result;
         } else {
             return visit_members(
                 item,
@@ -2409,6 +2517,13 @@ protected:
     ZPP_BITS_INLINE constexpr errc serialize_one(concepts::by_protocol auto && item)
     {
         using type = std::remove_cvref_t<decltype(item)>;
+
+        // One more message inside a message is one more level of nesting.
+        nesting_guard guard{*this};
+        if (failure(guard.result)) [[unlikely]] {
+            return guard.result;
+        }
+
         if constexpr (!std::is_void_v<SizeType>) {
             auto size_position = m_position;
             if (auto result = serialize_one(SizeType{});
@@ -2486,6 +2601,8 @@ protected:
 
     view_type m_data{};
     std::size_t m_position{};
+    [[no_unique_address]] traits::nesting_depth_t<nesting_depth_limit>
+        m_nesting{};
 };
 
 template <concepts::byte_view ByteView = std::vector<std::byte>, typename... Options>
@@ -2585,6 +2702,12 @@ public:
     constexpr static auto allocation_limit =
         traits::alloc_limit<Options...>();
 
+    constexpr static auto nesting_depth_limit =
+        traits::nesting_limit<Options...>();
+
+    constexpr static auto nesting_limited =
+        nesting_depth_limit != std::numeric_limits<std::size_t>::max();
+
     constexpr explicit in(ByteView && view, Options && ... options) : m_data(view)
     {
         static_assert(!resizable);
@@ -2630,6 +2753,11 @@ public:
     constexpr void reset(std::size_t position = 0)
     {
         m_position = position;
+    }
+
+    constexpr auto & nesting_depth()
+    {
+        return m_nesting;
     }
 
     constexpr static auto kind()
@@ -2756,11 +2884,21 @@ private:
                                                           type>) {
             return serialize_one(as_bytes(item));
         } else if constexpr (concepts::self_referencing<type>) {
-            return visit_members(
+            if constexpr (nesting_limited) {
+                if (m_nesting >= nesting_depth_limit) [[unlikely]] {
+                    return errc{std::errc::value_too_large};
+                }
+                ++m_nesting;
+            }
+            auto result = visit_members(
                 item,
                 [&](auto &&... items) constexpr {
                     return serialize_many(items...);
                 });
+            if constexpr (nesting_limited) {
+                --m_nesting;
+            }
+            return result;
         } else {
             return visit_members(
                 item,
@@ -3231,6 +3369,13 @@ private:
     ZPP_BITS_INLINE constexpr errc serialize_one(concepts::by_protocol auto && item)
     {
         using type = std::remove_cvref_t<decltype(item)>;
+
+        // One more message inside a message is one more level of nesting.
+        nesting_guard guard{*this};
+        if (failure(guard.result)) [[unlikely]] {
+            return guard.result;
+        }
+
         if constexpr (!std::is_void_v<SizeType>) {
             SizeType size{};
             if (auto result = serialize_one(size); failure(result))
@@ -3258,6 +3403,8 @@ private:
 
     view_type m_data{};
     std::size_t m_position{};
+    [[no_unique_address]] traits::nesting_depth_t<nesting_depth_limit>
+        m_nesting{};
 };
 
 template <typename Type, std::size_t Size, typename... Options>
@@ -4845,8 +4992,14 @@ struct pb
                     std::conditional_t<archive_type::no_enlarge_overflow,
                                        no_enlarge_overflow,
                                        enlarge_overflow>{},
-                    alloc_limit<archive_type::allocation_limit>{}};
+                    alloc_limit<archive_type::allocation_limit>{},
+                    nesting_limit<archive_type::nesting_depth_limit>{}};
             out.position() = archive.position();
+            if constexpr (archive_type::nesting_limited) {
+                // The depth reached so far has to travel with the nested
+                // archive; the level itself is counted by the caller.
+                out.nesting_depth() = archive.nesting_depth();
+            }
             if constexpr (concepts::self_referencing<type>) {
                 auto result = visit_members(
                     item,
@@ -5068,12 +5221,22 @@ struct pb
         requires(std::remove_cvref_t<decltype(archive)>::kind() ==
                  kind::in)
     {
+        using archive_type = std::remove_cvref_t<decltype(archive)>;
+
         auto data = archive.remaining_data();
         in in{std::span{data.data(), std::min(size, data.size())},
               size_varint{},
               endian::little{},
-              alloc_limit<std::remove_cvref_t<
-                  decltype(archive)>::allocation_limit>{}};
+              alloc_limit<archive_type::allocation_limit>{},
+              nesting_limit<archive_type::nesting_depth_limit>{}};
+
+        // Each nested message is read through a fresh archive, so the depth
+        // reached so far has to travel with it; the level itself is counted
+        // by the caller.
+        if constexpr (archive_type::nesting_limited) {
+            in.nesting_depth() = archive.nesting_depth();
+        }
+
         auto result = deserialize_fields(in, item);
         archive.position() += in.position();
         return result;


### PR DESCRIPTION
A self referencing type nests as deeply as the message says it does, and each
level costs a stack frame, so a message can ask for more nesting than the stack
has room for. This adds `zpp::bits::nesting_limit<N>{}`, which fails with
`std::errc::value_too_large` past `N` levels.

```cpp
zpp::bits::in in(data, zpp::bits::nesting_limit<128>{});
```

## Costs nothing when unused

The option is opt-in, and when it is absent nothing is emitted and nothing is
stored:

- The check lives inside the `concepts::self_referencing` branch that
  `serialize_one` already has, so it is never instantiated for a type that
  cannot nest without bound. Plainly nested containers are not affected however
  deep the type is.
- The depth counter is an empty `[[no_unique_address]]` member unless the
  option is present, so `sizeof` of an archive is unchanged.
  `test_nesting_limit.costs_nothing_when_not_requested` pins that layout with a
  `static_assert`.

For a type that does nest, the cost is a compare and an increment per level,
next to the allocation that level already performs.

## Scope

Both directions are covered, since serializing a deep structure recurses the
same way deserializing one does.

Protobuf messages nest through a fresh archive per level rather than by
recursing on a single archive, so the depth travels with the nested archive and
the level itself is counted by `serialize_one` for the message. Note that a
self referencing protobuf message does not currently compile here — a
`std::vector<Self>` field hits "deduced return type cannot be used before it is
defined", and a `unique_ptr` field is rejected by `check_type`, which accepts
only scalars, varints, containers and nested messages. That reproduces on
unmodified `main`, so the protobuf tests here nest statically instead.

## Tests

`test/src/test_nesting_limit.cpp` covers a self referencing type at and beyond
the limit in both directions, protobuf nesting at and beyond the limit in both
directions, an input that nests far deeper than the stack allows, that nesting
is unlimited without the option, that plainly nested containers are unaffected,
and the archive layout assertion.

## Verification

- **187 tests pass** under AddressSanitizer (clang, `-std=c++26`, `-Werror`);
  the same build against unmodified `main` runs **176**, so the difference is
  exactly the 11 new tests and there are no regressions.
- Each new test was confirmed failing before the change.
- Built outside `zpp.mk`, because the `-Wsign-conversion` flag recently added to
  `test/zpp_project.mk` currently fails the build on pre-existing warnings in
  `zpp_bits.h` and `test/include/test.h`, unrelated to this change.
- GCC was not exercised locally (the Homebrew GCC on this machine is broken
  against the macOS SDK); the GCC 11/12 CI jobs cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dn1bSVJQe33FQ7uBGZpewf