### PR TITLE
Skip protobuf fields the message has no member for

### DIFF
--- a/test/src/test_pb_unknown_fields.cpp
+++ b/test/src/test_pb_unknown_fields.cpp
@@ -1,0 +1,188 @@
+#include "test.h"
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace test_pb_unknown_fields
+{
+
+// A reader that knows only field 1.
+struct one_field
+{
+    zpp::bits::vint32_t a;
+
+    using serialize = zpp::bits::pb_protocol;
+};
+
+// A writer that also has field 2.
+struct two_fields
+{
+    zpp::bits::vint32_t a;
+    std::string b;
+
+    using serialize = zpp::bits::pb_protocol;
+};
+
+// A message that reserves field 1 and uses field 2.
+struct reserved_field
+{
+    [[no_unique_address]] zpp::bits::pb_reserved _1{};
+    zpp::bits::vint32_t b;
+
+    using serialize = zpp::bits::pb_protocol;
+};
+
+static auto read(auto & item, const std::vector<std::byte> & data)
+{
+    zpp::bits::in in{data, zpp::bits::size_varint{}};
+    return in(zpp::bits::unsized(item));
+}
+
+TEST(test_pb_unknown_fields, newer_writer_to_older_reader)
+{
+    two_fields newer{.a = 1, .b = "AAAAAAAA"};
+
+    std::vector<std::byte> data;
+    zpp::bits::out{data, zpp::bits::size_varint{}}(
+        zpp::bits::unsized(newer))
+        .or_throw();
+
+    one_field older;
+    ASSERT_EQ(read(older, data), std::errc{});
+    EXPECT_EQ(older.a.value, 1);
+}
+
+TEST(test_pb_unknown_fields, unknown_length_delimited_before_known)
+{
+    // field 2, length delimited, "AAAA", then field 1 = 7
+    std::vector<std::byte> data{
+        std::byte{0x12}, std::byte{0x04}, std::byte{0x41}, std::byte{0x41},
+        std::byte{0x41}, std::byte{0x41}, std::byte{0x08}, std::byte{0x07}};
+
+    one_field item;
+    ASSERT_EQ(read(item, data), std::errc{});
+    EXPECT_EQ(item.a.value, 7);
+}
+
+TEST(test_pb_unknown_fields, unknown_varint_before_known)
+{
+    // field 2 varint = 8, then field 1 = 7. The unknown value byte is itself
+    // a valid tag for field 1, so a reader that fails to skip it reads 8.
+    std::vector<std::byte> data{std::byte{0x10},
+                                std::byte{0x08},
+                                std::byte{0x08},
+                                std::byte{0x07}};
+
+    one_field item;
+    ASSERT_EQ(read(item, data), std::errc{});
+    EXPECT_EQ(item.a.value, 7);
+}
+
+TEST(test_pb_unknown_fields, unknown_fixed_32_before_known)
+{
+    // field 3 fixed 32, then field 1 = 7
+    std::vector<std::byte> data{
+        std::byte{0x1d}, std::byte{0xde}, std::byte{0xad}, std::byte{0xbe},
+        std::byte{0xef}, std::byte{0x08}, std::byte{0x07}};
+
+    one_field item;
+    ASSERT_EQ(read(item, data), std::errc{});
+    EXPECT_EQ(item.a.value, 7);
+}
+
+TEST(test_pb_unknown_fields, unknown_fixed_64_before_known)
+{
+    // field 3 fixed 64, then field 1 = 7
+    std::vector<std::byte> data{
+        std::byte{0x19}, std::byte{0x01}, std::byte{0x02}, std::byte{0x03},
+        std::byte{0x04}, std::byte{0x05}, std::byte{0x06}, std::byte{0x07},
+        std::byte{0x08}, std::byte{0x08}, std::byte{0x07}};
+
+    one_field item;
+    ASSERT_EQ(read(item, data), std::errc{});
+    EXPECT_EQ(item.a.value, 7);
+}
+
+TEST(test_pb_unknown_fields, unknown_field_payload_is_not_interpreted)
+{
+    // An unknown length delimited field whose payload would read as
+    // "field 1 = 99" if it were mistaken for a tag stream.
+    std::vector<std::byte> data{std::byte{0x12},
+                                std::byte{0x02},
+                                std::byte{0x08},
+                                std::byte{0x63}};
+
+    one_field item{.a = 1};
+    ASSERT_EQ(read(item, data), std::errc{});
+    EXPECT_EQ(item.a.value, 1);
+}
+
+TEST(test_pb_unknown_fields, reserved_field_number_is_skipped)
+{
+    // field 1 (reserved), length delimited, carrying two bytes that would
+    // read as "field 2 = 99" if the payload were mistaken for a tag stream,
+    // then the real field 2 = 7.
+    std::vector<std::byte> data{std::byte{0x0a},
+                                std::byte{0x02},
+                                std::byte{0x10},
+                                std::byte{0x63},
+                                std::byte{0x10},
+                                std::byte{0x07}};
+
+    reserved_field item;
+    ASSERT_EQ(read(item, data), std::errc{});
+    EXPECT_EQ(item.b.value, 7);
+}
+
+TEST(test_pb_unknown_fields, unknown_field_running_past_the_end_is_rejected)
+{
+    // field 2, length delimited, claiming 100 bytes that are not there.
+    std::vector<std::byte> data{
+        std::byte{0x12}, std::byte{0x64}, std::byte{0x41}, std::byte{0x41}};
+
+    one_field item;
+    EXPECT_EQ(read(item, data), std::errc::result_out_of_range);
+}
+
+TEST(test_pb_unknown_fields, unknown_varint_running_past_the_end_is_rejected)
+{
+    // field 2 varint whose continuation bits never terminate.
+    std::vector<std::byte> data{
+        std::byte{0x10}, std::byte{0x80}, std::byte{0x80}, std::byte{0x80}};
+
+    one_field item;
+    EXPECT_EQ(read(item, data), std::errc::result_out_of_range);
+}
+
+TEST(test_pb_unknown_fields, unsupported_wire_type_is_rejected)
+{
+    // field 4 with wire type 3, a deprecated group.
+    std::vector<std::byte> data{std::byte{0x23}, std::byte{0x01}};
+
+    one_field item;
+    EXPECT_EQ(read(item, data), std::errc::protocol_error);
+}
+
+TEST(test_pb_unknown_fields, field_number_zero_is_still_rejected)
+{
+    std::vector<std::byte> data{std::byte{0x00}, std::byte{0x01}};
+
+    one_field item;
+    EXPECT_EQ(read(item, data), std::errc::protocol_error);
+}
+
+TEST(test_pb_unknown_fields, known_fields_still_round_trip)
+{
+    two_fields item{.a = 4321, .b = "round trip"};
+
+    std::vector<std::byte> data;
+    zpp::bits::out{data, zpp::bits::size_varint{}}(zpp::bits::unsized(item))
+        .or_throw();
+
+    two_fields restored;
+    ASSERT_EQ(read(restored, data), std::errc{});
+    EXPECT_EQ(restored.a.value, item.a.value);
+    EXPECT_EQ(restored.b, item.b);
+}
+
+} // namespace test_pb_unknown_fields

--- a/zpp_bits.h
+++ b/zpp_bits.h
@@ -5280,6 +5280,47 @@ struct pb
         return {};
     }
 
+    ZPP_BITS_INLINE constexpr static errc skip_bytes(auto & archive,
+                                                     std::size_t count)
+    {
+        if (count > archive.remaining_data().size()) [[unlikely]] {
+            return errc{std::errc::result_out_of_range};
+        }
+
+        archive.position() += count;
+        return errc{};
+    }
+
+    // Advances past a field the message has no member for, so that the
+    // fields following it are still read at the right offset. Without this
+    // the reader would carry on from the middle of the field and parse the
+    // remainder of the message against the wrong offsets.
+    ZPP_BITS_INLINE constexpr static errc skip_field(auto & archive,
+                                                     wire_type field_type)
+    {
+        switch (field_type) {
+        case wire_type::varint: {
+            vsize_t discarded;
+            return archive(discarded);
+        }
+        case wire_type::fixed_64:
+            return skip_bytes(archive, sizeof(std::uint64_t));
+        case wire_type::fixed_32:
+            return skip_bytes(archive, sizeof(std::uint32_t));
+        case wire_type::length_delimited: {
+            vsize_t length;
+            if (auto result = archive(length); failure(result))
+                [[unlikely]] {
+                return result;
+            }
+            return skip_bytes(archive, length);
+        }
+        default:
+            // Groups are deprecated and are not supported.
+            return errc{std::errc::protocol_error};
+        }
+    }
+
     template <std::size_t Index = 0>
     ZPP_BITS_INLINE constexpr static auto
     deserialize_field(auto & archive,
@@ -5292,7 +5333,7 @@ struct pb
             if (!field_num) [[unlikely]] {
                 return errc{std::errc::protocol_error};
             }
-            return errc{};
+            return skip_field(archive, field_type);
         } else if (field_number_from_struct<type, Index>() != field_num) {
             return deserialize_field<Index + 1>(
                 archive, item, field_num, field_type);
@@ -5341,6 +5382,10 @@ struct pb
                 archive,
                 field_type,
                 static_cast<typename type::pb_field_type &>(item));
+        } else if constexpr (concepts::empty<type>) {
+            // A reserved field number. There is nothing to read into, but
+            // the field still occupies the input and has to be skipped.
+            return skip_field(archive, field_type);
         } else if constexpr (!concepts::container<type>) {
             return archive(item);
         } else if constexpr (concepts::associative_container<type> &&


### PR DESCRIPTION
An unrecognised field number was accepted without consuming the field, so the
reader carried on from the middle of it and read the rest of the message at the
wrong offsets. Reserved field numbers behaved the same way, since an empty
member reads nothing.

## Why it matters beyond malformed input

A writer that has added a field sends `{a = 1, b = "AAAAAAAA"}`:

```
08 01 12 08 41 41 41 41 41 41 41 41
```

A reader that only knows field 1 read `08 01` (`a = 1`), took the tag of field
2, skipped nothing, then read `08` as a tag and `0x41` as its value:

```
a = 65      err = 0     (success)
```

The correct answer is `a = 1`. It reports success, so nothing downstream can
tell. Whoever controls an unknown field also controls what the fields after it
decode to — `12 08 63` sets `a = 99` on a reader that has no field 2.

## The change

`skip_field` advances past the field using the wire type already in hand:

| wire type | action |
|---|---|
| `varint` | decode and discard |
| `fixed_64` / `fixed_32` | advance 8 / 4 bytes |
| `length_delimited` | read the length, advance by it |
| groups (3, 4) and anything else | `protocol_error` |

Groups are deprecated, so rejecting them beats guessing. Every advance goes
through `skip_bytes`, which bounds it against `remaining_data()` — required
here, since otherwise `position += length` would push the reader past the end
of the archive and break the invariant every bounds check relies on.

The same skip handles reserved field numbers (`pb_reserved`), which desynced
identically.

## Tests

`test/src/test_pb_unknown_fields.cpp` covers an older reader against a newer
writer, an unknown field of each wire type ahead of a known one, an unknown
payload that would read as a known field if mistaken for a tag stream, a
reserved field number, unknown fields running past the end, an unsupported wire
type, and that field number zero is still rejected.

Two of these initially passed by accident — the desync happened to land on a
valid tag — so they were tightened until they failed for the right reason. That
is what exposed the reserved field case. 8 of the 12 were confirmed failing
before the change.

## Verification

- Full suite via `zpp.mk`: **217/217 passing** under AddressSanitizer (clang,
  `-std=c++26`, `-Werror`), including the 12 existing `test_pb_protocol` tests.
- libFuzzer + ASan/UBSan over the protobuf path with the skip in place:
  **43.2M executions, no findings**.
- GCC was not exercised locally (the Homebrew GCC on this machine is broken
  against the macOS SDK); the GCC 11/12 CI jobs cover it.

## Note

An earlier run of this fuzzer, before this branch was rebased onto current
main, hit an 11.3 GB allocation from the 8 byte input
`22 c6 c6 c6 c6 0a 04 0a` — a repeated field declaring 2,832,311,110 elements.
That is the `reserve()` path fixed in #216; the same input runs clean on top of
current main. Recorded here only because it independently confirms that fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dn1bSVJQe33FQ7uBGZpewf